### PR TITLE
Migrate R packages to manylinux P3M binaries

### DIFF
--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -87,7 +87,7 @@ RUN git clone --branch R4.5.0 --depth 1 https://github.com/rocker-org/rocker-ver
     chmod -R 700 /rocker_scripts/ && \
     /rocker_scripts/install_R_source.sh
 
-ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
+ENV CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_VERSION}"
 
 # RStudio ENVs
 ENV S6_VERSION=v2.1.0.2
@@ -119,12 +119,6 @@ RUN /rocker_scripts/install_rstudio.sh
 RUN /opt/install-system-libs.sh && \
     # Install additional system libs needed by R packages
     /opt/install-system-libs-R.sh && \
-    # arrow >= 21 requires cmake >= 3.26 when users install into renv projects
-    CMAKE_VERSION="$(cmake --version | awk 'NR == 1 { print $3 }')" && \
-    if ! dpkg --compare-versions "$CMAKE_VERSION" ge "3.26"; then \
-    echo "cmake >= 3.26 is required for arrow; found $CMAKE_VERSION"; \
-    exit 1; \
-    fi && \
     # Configure R for CUDA if parent image has CUDA
     if ! [[ -z "${CUDA_VERSION}" ]]; then /rocker_scripts/config_R_cuda.sh; fi && \
     # Install useful additional packages
@@ -144,16 +138,10 @@ RUN /opt/install-system-libs.sh && \
     rm -rf /var/lib/apt/lists/*
 
 
-# Install Arrow, og sjekk https://cran.r-project.org/src/contrib/Archive/arrow/ om R-versjonen ligger der. Slik at du treffer riktig versjon. Bruk også "apt-cache madison libarrow-dev"
+# Install Arrow as Posit portable (manylinux_2_28) binary — no system libarrow
 ARG ARROW_VERSION="24.0.0"
 ENV ARROW_VERSION=${ARROW_VERSION}
 RUN /opt/install-arrow.sh
-
-ENV ARROW_HOME="/usr"
-ENV ARROW_USE_PKG_CONFIG="TRUE"
-ENV LIBARROW_BINARY="FALSE"
-ENV LIBARROW_BUILD="FALSE"
-ENV PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig"
 
 # Setting up environment variables for Oracle
 ENV OCI_INC=/usr/include/oracle/21/client64

--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -67,6 +67,9 @@ USER 1000
 # R Config
 ARG R_VERSION="4.4.0"
 ENV R_VERSION=${R_VERSION}
+# P3M manylinux path must be major.minor (4.4), not patch (4.4.0) — else source tarballs are served.
+ARG R_MINOR="4.4"
+ENV R_MINOR=${R_MINOR}
 ENV R_HOME="/usr/local/lib/R"
 ENV DEFAULT_USER="${USERNAME}"
 
@@ -87,7 +90,8 @@ RUN git clone --branch R4.5.0 --depth 1 https://github.com/rocker-org/rocker-ver
     chmod -R 700 /rocker_scripts/ && \
     /rocker_scripts/install_R_source.sh
 
-ENV CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_VERSION}"
+# P3M manylinux requires major.minor (see R_MINOR) — patch form serves source packages.
+ENV CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_MINOR}"
 
 # RStudio ENVs
 ENV S6_VERSION=v2.1.0.2

--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -90,8 +90,9 @@ RUN git clone --branch R4.5.0 --depth 1 https://github.com/rocker-org/rocker-ver
     chmod -R 700 /rocker_scripts/ && \
     /rocker_scripts/install_R_source.sh
 
-# P3M manylinux requires major.minor (see R_MINOR) — patch form serves source packages.
-ENV CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_MINOR}"
+# Rocker tidyverse/geospatial expect Posit __linux__/noble binaries (HTTPUserAgent).
+# Manylinux is used explicitly in install-arrow.sh / r-packages-src.R / Rprofile.site.
+ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
 
 # RStudio ENVs
 ENV S6_VERSION=v2.1.0.2

--- a/docker/rstudio/Rprofile.site
+++ b/docker/rstudio/Rprofile.site
@@ -3,13 +3,15 @@ home <- Sys.getenv("R_HOME")
 .libPaths(c(file.path(home, "lib"), .libPaths()))
 
 # Manylinux portable binaries first; noble proxy as fallback for packages without manylinux.
+# P3M path segment must be major.minor (4.4), not patch (4.4.0) — else source packages are served.
 r_ver <- Sys.getenv("R_VERSION", unset = as.character(getRversion()))
+r_minor <- sub("^([0-9]+\\.[0-9]+).*", "\\1", r_ver)
 options(repos = c(
-  P3M = sprintf("https://nexus.ssb.no/repository/r-p3m/%s", r_ver),
+  P3M = sprintf("https://nexus.ssb.no/repository/r-p3m/%s", r_minor),
   CRAN = "https://nexus.ssb.no/repository/packagemanager-rstudio-noble/"
 ))
 options(renv.config.repos.override = getOption("repos"))
-rm(r_ver)
+rm(r_ver, r_minor)
 
 # --- XLConnect: pek Java/JAR-hentingen mot intern Nexus (Maven-proxy) ---
 # Merk: Dette er R-side env, satt tidlig i økten.

--- a/docker/rstudio/Rprofile.site
+++ b/docker/rstudio/Rprofile.site
@@ -2,10 +2,14 @@
 home <- Sys.getenv("R_HOME")
 .libPaths(c(file.path(home, "lib"), .libPaths()))
 
-r <- getOption("repos")
-r["CRAN"] <- "https://nexus.ssb.no/repository/packagemanager-rstudio-noble/"
-options(repos = r)
-rm(r)
+# Manylinux portable binaries first; noble proxy as fallback for packages without manylinux.
+r_ver <- Sys.getenv("R_VERSION", unset = as.character(getRversion()))
+options(repos = c(
+  P3M = sprintf("https://nexus.ssb.no/repository/r-p3m/%s", r_ver),
+  CRAN = "https://nexus.ssb.no/repository/packagemanager-rstudio-noble/"
+))
+options(renv.config.repos.override = getOption("repos"))
+rm(r_ver)
 
 # --- XLConnect: pek Java/JAR-hentingen mot intern Nexus (Maven-proxy) ---
 # Merk: Dette er R-side env, satt tidlig i økten.

--- a/docker/rstudio/r-packages-src.R
+++ b/docker/rstudio/r-packages-src.R
@@ -2,10 +2,14 @@
 
 # Build-time install: manylinux portable first, noble binaries as fallback, CRAN last.
 # (GHA cannot rely on Nexus; runtime Rprofile.site points at Nexus mirrors.)
+#
+# P3M manylinux URL must use major.minor (4.4), not patch (4.4.0).
+# Empirically: .../4.4.0/... serves X-Package-Type=source; .../4.4/... serves binary.
 r_ver <- Sys.getenv("R_VERSION", unset = as.character(getRversion()))
+r_minor <- sub("^([0-9]+\\.[0-9]+).*", "\\1", r_ver)
 manylinux <- sprintf(
   "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/%s",
-  r_ver
+  r_minor
 )
 noble <- c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
 cran  <- c(CRAN = "https://cloud.r-project.org")
@@ -13,7 +17,7 @@ cran  <- c(CRAN = "https://cloud.r-project.org")
 .libPaths(unique(c("/usr/local/lib/R/site-library", .libPaths())))
 options(repos = c(P3M = manylinux, CRAN = noble[["CRAN"]]))
 
-message("R_VERSION: ", r_ver)
+message("R_VERSION: ", r_ver, " → manylinux path: ", r_minor)
 message("Repos: ", paste(getOption("repos"), collapse = ", "))
 message(".libPaths(): ", paste(.libPaths(), collapse = " | "))
 

--- a/docker/rstudio/r-packages-src.R
+++ b/docker/rstudio/r-packages-src.R
@@ -1,13 +1,19 @@
 #!/usr/bin/env Rscript
 
-# Be explicit about repos (Ubuntu 24.04 "noble" binary path) with CRAN fallback
-ppn <- c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
-cran <- c(CRAN = "https://cloud.r-project.org")
+# Build-time install: manylinux portable first, noble binaries as fallback, CRAN last.
+# (GHA cannot rely on Nexus; runtime Rprofile.site points at Nexus mirrors.)
+r_ver <- Sys.getenv("R_VERSION", unset = as.character(getRversion()))
+manylinux <- sprintf(
+  "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/%s",
+  r_ver
+)
+noble <- c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
+cran  <- c(CRAN = "https://cloud.r-project.org")
 
-# Use a sane library path (avoid writing into R_HOME/lib)
 .libPaths(unique(c("/usr/local/lib/R/site-library", .libPaths())))
-options(repos = ppn)
+options(repos = c(P3M = manylinux, CRAN = noble[["CRAN"]]))
 
+message("R_VERSION: ", r_ver)
 message("Repos: ", paste(getOption("repos"), collapse = ", "))
 message(".libPaths(): ", paste(.libPaths(), collapse = " | "))
 
@@ -17,7 +23,6 @@ pkgs <- c(
   "srvyr","eurostat","dggridR","tidyfst","plotly","klassR"
 )
 
-# Helper to install a set and report missing
 install_set <- function(p, repos = getOption("repos")) {
   missing <- setdiff(p, rownames(installed.packages()))
   if (length(missing)) {
@@ -29,29 +34,41 @@ install_set <- function(p, repos = getOption("repos")) {
   setdiff(p, rownames(installed.packages()))
 }
 
-# 1) Try PPM first
-still_missing <- install_set(pkgs, repos = ppn)
+# 1) Manylinux portable binaries
+still_missing <- install_set(pkgs, repos = manylinux)
 
-# 2) If simputation is still missing, force a CRAN fallback just for that pkg
-if ("simputation" %in% still_missing) {
-  message("Forcing CRAN fallback for simputation…")
-  install.packages("simputation", dependencies = TRUE, repos = cran, Ncpus = parallel::detectCores())
+# 2) Noble binaries for anything still missing (classic path)
+if (length(still_missing)) {
+  message("Noble fallback for: ", paste(still_missing, collapse = ", "))
+  still_missing <- install_set(still_missing, repos = noble)
 }
 
-# 3) Verify simputation really installed, or stop with a loud error
-if (!requireNamespace("simputation", quietly = TRUE)) {
-  ip <- setdiff("simputation", rownames(installed.packages()))
-  stop("simputation did not install. Still missing: ", paste(ip, collapse = ", "),
+# 3) CRAN source last resort (historically needed for simputation)
+if (length(still_missing)) {
+  message("CRAN fallback for: ", paste(still_missing, collapse = ", "))
+  still_missing <- install_set(still_missing, repos = cran)
+}
+
+if ("simputation" %in% still_missing || !requireNamespace("simputation", quietly = TRUE)) {
+  stop("simputation did not install. Still missing: ",
+       paste(setdiff(pkgs, rownames(installed.packages())), collapse = ", "),
        "\nCheck the build log above for the first error.")
-} else {
-  message("simputation installed OK: ", as.character(packageVersion("simputation")))
+}
+message("simputation installed OK: ", as.character(packageVersion("simputation")))
+
+still_missing <- setdiff(pkgs, rownames(installed.packages()))
+if (length(still_missing)) {
+  stop("Packages still missing after manylinux/noble/CRAN: ",
+       paste(still_missing, collapse = ", "))
 }
 
-# 4) ROracle (you already fixed libaio/libnsl)
+# 4) ROracle (prebuilt tarball; needs libaio/libnsl already in image)
 install.packages("/tmp/ROracle_1.4-1_R_x86_64-unknown-linux-gnu.tar.gz", repos = NULL, type = "source")
 
 # 5) GitHub packages (avoid surprise upgrades of deps)
-if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes", repos = cran)
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes", repos = manylinux)
+}
 gh <- c(
   "statisticsnorway/ssb-pris",
   "statisticsnorway/ssb-kostra",

--- a/docker/rstudio/r-packages-src.R
+++ b/docker/rstudio/r-packages-src.R
@@ -5,19 +5,27 @@
 #
 # P3M manylinux URL must use major.minor (4.4), not patch (4.4.0).
 # Empirically: .../4.4.0/... serves X-Package-Type=source; .../4.4/... serves binary.
+#
+# Use Depends/Imports/LinkingTo only — dependencies=TRUE also pulls Suggests
+# (e.g. Deriv), which is source-only and fails to compile on R 4.4.
 r_ver <- Sys.getenv("R_VERSION", unset = as.character(getRversion()))
 r_minor <- sub("^([0-9]+\\.[0-9]+).*", "\\1", r_ver)
 manylinux <- sprintf(
   "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/%s",
   r_minor
 )
-noble <- c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
-cran  <- c(CRAN = "https://cloud.r-project.org")
+# Explicit noble path (works with Rscript --vanilla; no HTTPUserAgent needed)
+noble <- sprintf(
+  "https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/%s",
+  r_minor
+)
+cran <- "https://cloud.r-project.org"
+hard_deps <- c("Depends", "Imports", "LinkingTo")
 
 .libPaths(unique(c("/usr/local/lib/R/site-library", .libPaths())))
-options(repos = c(P3M = manylinux, CRAN = noble[["CRAN"]]))
+options(repos = c(P3M = manylinux, CRAN = noble))
 
-message("R_VERSION: ", r_ver, " → manylinux path: ", r_minor)
+message("R_VERSION: ", r_ver, " → path: ", r_minor)
 message("Repos: ", paste(getOption("repos"), collapse = ", "))
 message(".libPaths(): ", paste(.libPaths(), collapse = " | "))
 
@@ -27,11 +35,16 @@ pkgs <- c(
   "srvyr","eurostat","dggridR","tidyfst","plotly","klassR"
 )
 
-install_set <- function(p, repos = getOption("repos")) {
+install_set <- function(p, repos) {
   missing <- setdiff(p, rownames(installed.packages()))
   if (length(missing)) {
     message("Installing: ", paste(missing, collapse = ", "))
-    install.packages(missing, dependencies = TRUE, repos = repos, Ncpus = parallel::detectCores())
+    install.packages(
+      missing,
+      dependencies = hard_deps,
+      repos = repos,
+      Ncpus = parallel::detectCores()
+    )
   } else {
     message("Already installed: ", paste(p, collapse = ", "))
   }
@@ -41,7 +54,7 @@ install_set <- function(p, repos = getOption("repos")) {
 # 1) Manylinux portable binaries
 still_missing <- install_set(pkgs, repos = manylinux)
 
-# 2) Noble binaries for anything still missing (classic path)
+# 2) Noble binaries for anything still missing
 if (length(still_missing)) {
   message("Noble fallback for: ", paste(still_missing, collapse = ", "))
   still_missing <- install_set(still_missing, repos = noble)
@@ -53,7 +66,7 @@ if (length(still_missing)) {
   still_missing <- install_set(still_missing, repos = cran)
 }
 
-if ("simputation" %in% still_missing || !requireNamespace("simputation", quietly = TRUE)) {
+if (!requireNamespace("simputation", quietly = TRUE)) {
   stop("simputation did not install. Still missing: ",
        paste(setdiff(pkgs, rownames(installed.packages())), collapse = ", "),
        "\nCheck the build log above for the first error.")
@@ -69,9 +82,9 @@ if (length(still_missing)) {
 # 4) ROracle (prebuilt tarball; needs libaio/libnsl already in image)
 install.packages("/tmp/ROracle_1.4-1_R_x86_64-unknown-linux-gnu.tar.gz", repos = NULL, type = "source")
 
-# 5) GitHub packages (avoid surprise upgrades of deps)
+# 5) GitHub packages (avoid surprise upgrades of hard deps)
 if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes", repos = manylinux)
+  install.packages("remotes", repos = manylinux, dependencies = hard_deps)
 }
 gh <- c(
   "statisticsnorway/ssb-pris",
@@ -83,4 +96,6 @@ gh <- c(
   "statisticsnorway/ssb-easysdctable",
   "statisticsnorway/ReGenesees"
 )
-for (repo in gh) remotes::install_github(repo, upgrade = "never", dependencies = TRUE)
+for (repo in gh) {
+  remotes::install_github(repo, upgrade = "never", dependencies = hard_deps)
+}

--- a/docker/rstudio/r-packages-src.R
+++ b/docker/rstudio/r-packages-src.R
@@ -29,6 +29,21 @@ message("R_VERSION: ", r_ver, " → path: ", r_minor)
 message("Repos: ", paste(getOption("repos"), collapse = ", "))
 message(".libPaths(): ", paste(.libPaths(), collapse = " | "))
 
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes", repos = manylinux, dependencies = hard_deps)
+}
+
+# Deriv 4.3.0 is source-only on P3M and fails to compile on R 4.4 (R_ClosureFormals).
+# 4.2.0 still has a manylinux binary; required via VIM → car → pbkrtest → doBy → Deriv.
+message("Pinning Deriv@4.2.0 (last known manylinux binary)…")
+remotes::install_version(
+  "Deriv",
+  version = "4.2.0",
+  repos = manylinux,
+  dependencies = hard_deps,
+  upgrade = "never"
+)
+
 pkgs <- c(
   "RJDemetra","SmallCountRounding","PxWebApiData","openxlsx","SSBtools","GISSB",
   "GaussSuppression","tinytest","configr","DT","dcmodify","simputation","survey",
@@ -83,9 +98,6 @@ if (length(still_missing)) {
 install.packages("/tmp/ROracle_1.4-1_R_x86_64-unknown-linux-gnu.tar.gz", repos = NULL, type = "source")
 
 # 5) GitHub packages (avoid surprise upgrades of hard deps)
-if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes", repos = manylinux, dependencies = hard_deps)
-}
 gh <- c(
   "statisticsnorway/ssb-pris",
   "statisticsnorway/ssb-kostra",

--- a/docker/rstudio/rstudio.service
+++ b/docker/rstudio/rstudio.service
@@ -1,15 +1,23 @@
 [Unit]
-Description=Service file for rstudio
+Description=RStudio (Docker Compose)
+Wants=network-online.target
+After=docker.service network-online.target
 Requires=docker.service
-After=docker.service
+RequiresMountsFor=/ssb/bruker /ssb/stamme01 /ssb/stamme02 /ssb/stamme03 /ssb/stamme04 /ssb/cloud_sync /ssb/share
 
 [Service]
 Type=oneshot
-RemainAfterExit=true
-User=github-runner
 WorkingDirectory=/home/github-runner/rstudio-onprem-ghashr/docker/rstudio
-ExecStart=/bin/docker compose -f docker-compose.yml up --pull always -d
-ExecStop=/bin/docker compose -f docker-compose.yml down
+User=github-runner
+
+# Pull newest images and (re)create containers in one go
+ExecStart=/usr/bin/docker compose -f docker-compose.yml up -d --pull always --remove-orphans --force-recreate
+ExecReload=/usr/bin/docker compose -f docker-compose.yml up -d --pull always --remove-orphans --force-recreate
+ExecStop=/usr/bin/docker compose -f docker-compose.yml down
+
+RemainAfterExit=yes
+TimeoutStartSec=0
+TimeoutStopSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/docker/rstudio/scripts/install-arrow.sh
+++ b/docker/rstudio/scripts/install-arrow.sh
@@ -22,13 +22,7 @@ echo "    ↪ repos              : ${REPOS}"
 Rscript --vanilla -e "install.packages('remotes', repos='${REPOS}', quiet=TRUE)"
 Rscript --vanilla -e "remotes::install_version('arrow', version='${ARROW_VERSION}', repos='${REPOS}', dependencies=c('Depends','Imports','LinkingTo'), upgrade='never')"
 
-Rscript --vanilla <<'RS'
-caps <- arrow::arrow_info()$capabilities
-print(caps)
-if (is.null(caps) || !any(unlist(caps))) {
-  stop("arrow installed but capabilities are all FALSE / unavailable")
-}
-message("arrow ", as.character(packageVersion("arrow")), " OK")
-RS
+# Assert load + capabilities (avoid heredoc — CRLF-safe in CI)
+Rscript --vanilla -e "caps <- arrow::arrow_info()\$capabilities; print(caps); if (is.null(caps) || !any(unlist(caps))) stop('arrow capabilities all FALSE'); message('arrow ', as.character(packageVersion('arrow')), ' OK')"
 
 echo "✅  arrow ${ARROW_VERSION} (portable manylinux) installed."

--- a/docker/rstudio/scripts/install-arrow.sh
+++ b/docker/rstudio/scripts/install-arrow.sh
@@ -1,164 +1,30 @@
 #!/usr/bin/env bash
 # --------------------------------------------------------------------
-# /opt/install_arrow.sh       Ubuntu 24.04  ◇  Apache Arrow (all libs)
-#
-#   ARROW_VERSION=18.0.0
-#     → libarrow* 18.0.0-1   +   arrow 18.0.0   –or– 18.0.0.1, etc.
+# /opt/install-arrow.sh
+# Install R arrow as Posit portable (manylinux_2_28) binary — no APT/system libs.
 # --------------------------------------------------------------------
 set -euo pipefail
-CRAN=https://cloud.r-project.org
 
-: "${ARROW_VERSION:?ARROW_VERSION (e.g. 18.0.0) must be exported}"
-echo "▶  Arrow APT target  : $ARROW_VERSION"
-DISTRO_ID=$(lsb_release -is 2>/dev/null | tr A-Z a-z || true)
-CODENAME=$(lsb_release -cs 2>/dev/null || true)
-if [[ -z "$DISTRO_ID" || -z "$CODENAME" ]]; then
-  if [[ -r /etc/os-release ]]; then
-    # shellcheck disable=SC1091
-    . /etc/os-release
-    DISTRO_ID=${ID:-$DISTRO_ID}
-    CODENAME=${VERSION_CODENAME:-$CODENAME}
-  fi
-fi
-if [[ "$DISTRO_ID" != "ubuntu" ]]; then
-  echo "!! Unsupported distro: ${DISTRO_ID:-unknown} (expected ubuntu)"
-  exit 1
-fi
-echo "    ↪ Ubuntu codename : ${CODENAME:-unknown}"
+: "${ARROW_VERSION:?ARROW_VERSION (e.g. 24.0.0) must be exported}"
+: "${R_VERSION:?R_VERSION (e.g. 4.4.0) must be exported}"
 
-############################################################################
-# 1)  Add Arrow APT repo (idempotent)
-############################################################################
-apt-get update -qq
-apt-get install -y --no-install-recommends ca-certificates lsb-release wget gnupg
-wget -q "https://packages.apache.org/artifactory/arrow/${DISTRO_ID}/apache-arrow-apt-source-latest-${CODENAME}.deb"
-apt-get install -y ./apache-arrow-apt-source-latest-${CODENAME}.deb
-rm       ./apache-arrow-apt-source-latest-${CODENAME}.deb
-apt-get update -qq
+# GHA/build: public P3M (Nexus often unreachable). Runtime users use Nexus via Rprofile.site.
+REPOS="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_VERSION}"
 
-############################################################################
-# 2)  Resolve APT revisions
-############################################################################
-LATEST_REV=$(apt-cache madison libarrow-dev | awk -F'|' 'NR==1{gsub(/^ +| +$/, "", $2); print $2; exit}')
-LATEST_VER=${LATEST_REV%-*}
-REQ_SERIES=$(echo "$ARROW_VERSION" | awk -F. '{print $1"."$2}')
-LATEST_SERIES=$(echo "$LATEST_VER" | awk -F. '{print $1"."$2}')
+echo "▶  Arrow portable binary : ${ARROW_VERSION}"
+echo "    ↪ R_VERSION          : ${R_VERSION}"
+echo "    ↪ repos              : ${REPOS}"
 
-REV=$(apt-cache madison libarrow-dev |
-      awk -F'|' -v v="$ARROW_VERSION" '{gsub(/^ +| +$/, "", $2); if($2~("^"v"-")){print $2; exit}}')
+Rscript --vanilla -e "install.packages('remotes', repos='${REPOS}', quiet=TRUE)"
+Rscript --vanilla -e "remotes::install_version('arrow', version='${ARROW_VERSION}', repos='${REPOS}', dependencies=c('Depends','Imports','LinkingTo'), upgrade='never')"
 
-echo "    ↪ APT latest rev  : $LATEST_REV"
-if [[ -n "$REV" ]]; then
-  echo "    ↪ APT revision    : $REV"
-fi
-echo "    ↪ APT series      : $LATEST_SERIES (req $REQ_SERIES)"
-
-############################################################################
-# 3)  Install Arrow dev libs at one exact APT revision
-############################################################################
-[[ -z $REV ]] && { echo "!! libarrow-dev $ARROW_VERSION not in repo"; exit 1; }
-
-# Arrow patch releases can reuse the same ABI package names, e.g.
-# libarrow2300 exists at both 23.0.0-1 and 23.0.1-1. Pin the selected
-# revision so apt resolves transitive runtime dependencies consistently.
-cat >/etc/apt/preferences.d/apache-arrow-version <<EOF
-Package: libarrow* libparquet* libgandiva* gir1.2-arrow* gir1.2-parquet* gir1.2-gandiva*
-Pin: version $REV
-Pin-Priority: 1001
-EOF
-
-REQUIRED_PKGS=(
-  libarrow-dev libparquet-dev
-  libarrow-dataset-dev libarrow-compute-dev libarrow-acero-dev
-  libarrow-flight-dev libarrow-flight-sql-dev
-  libgandiva-dev
-)
-OPTIONAL_PKGS=(
-  libarrow-glib-dev libparquet-glib-dev
-  libarrow-dataset-glib-dev
-  libarrow-flight-glib-dev libarrow-flight-sql-glib-dev
-  libgandiva-glib-dev
-  gir1.2-arrow-1.0 gir1.2-parquet-1.0 gir1.2-arrow-dataset-1.0
-  gir1.2-arrow-flight-1.0 gir1.2-arrow-flight-sql-1.0
-  gir1.2-gandiva-1.0
-)
-
-have_rev() {
-  apt-cache madison "$1" | awk -F'|' -v v="$REV" '{gsub(/^ +| +$/, "", $2); if($2==v){found=1}} END{exit !found}'
+Rscript --vanilla <<'RS'
+caps <- arrow::arrow_info()$capabilities
+print(caps)
+if (is.null(caps) || !any(unlist(caps))) {
+  stop("arrow installed but capabilities are all FALSE / unavailable")
 }
-
-INSTALL_PKGS=()
-for pkg in "${REQUIRED_PKGS[@]}"; do
-  if have_rev "$pkg"; then
-    INSTALL_PKGS+=("${pkg}=$REV")
-  else
-    echo "!! required package missing at $REV: $pkg"
-    exit 1
-  fi
-done
-
-SKIPPED_OPTIONAL=()
-for pkg in "${OPTIONAL_PKGS[@]}"; do
-  if have_rev "$pkg"; then
-    INSTALL_PKGS+=("${pkg}=$REV")
-  else
-    SKIPPED_OPTIONAL+=("$pkg")
-  fi
-done
-
-apt-get install -y --allow-downgrades --allow-change-held-packages \
-  --no-install-recommends "${INSTALL_PKGS[@]}"
-
-if ((${#SKIPPED_OPTIONAL[@]})); then
-  echo "    ↪ Skipped optional packages (not in repo at $REV): ${SKIPPED_OPTIONAL[*]}"
-fi
-
-############################################################################
-# 4)  Decide the *exact* R package version
-############################################################################
-R_ARROW_VERSION=$(Rscript --vanilla - "$ARROW_VERSION" "$CRAN" <<'RS'
-req  <- commandArgs(TRUE)[1]          # "18.0.0"
-cran <- commandArgs(TRUE)[2]
-
-collect_versions <- function() {
-  res <- character()
-  # current release
-  try(
-    res <- c(res, available.packages(repos = cran)["arrow", "Version"]),
-    silent = TRUE)
-  # archive listing
-  html <- tryCatch(readLines(file.path(cran,"src/contrib/Archive/arrow/"), warn = FALSE),
-                   error=function(e) character())
-  res <- c(res, unique(sub(".*arrow_([0-9.]+)\\.tar\\.gz.*", "\\1",
-                           grep("arrow_", html, value = TRUE))))
-  unique(res)
-}
-
-vers <- collect_versions()
-
-if (req %in% vers) {
-  sel <- req                                 # exact match
-} else {
-  pref <- grep(paste0("^", req, "\\."), vers, value = TRUE)
-  if (length(pref)) {
-    sel <- as.character(max(package_version(pref)))  # 18.0.0.x
-  } else {
-    maj  <- sub("(\\d+\\.\\d+).*", "\\1", req)       # 18.0
-    cand <- vers[startsWith(vers, maj)]
-    stopifnot(length(cand) > 0)                      # abort if none
-    sel <- as.character(max(package_version(cand)))  # highest 18.0.*
-  }
-}
-cat(sel)
+message("arrow ", as.character(packageVersion("arrow")), " OK")
 RS
-)
-echo "    ↪ R tarball ver  : $R_ARROW_VERSION"
 
-############################################################################
-# 5)  Install that exact R version, linking to system libarrow
-############################################################################
-export LIBARROW_BUILD=FALSE LIBARROW_BINARY=FALSE ARROW_USE_PKG_CONFIG=TRUE
-Rscript --vanilla -e "install.packages('remotes', repos='$CRAN', quiet=TRUE)"
-Rscript --vanilla -e "remotes::install_version('arrow', version='$R_ARROW_VERSION', repos='$CRAN', dependencies=c('Depends','Imports','LinkingTo'))"
-
-echo "✅  libarrow $REV  +  arrow $R_ARROW_VERSION (R) installed."
+echo "✅  arrow ${ARROW_VERSION} (portable manylinux) installed."

--- a/docker/rstudio/scripts/install-arrow.sh
+++ b/docker/rstudio/scripts/install-arrow.sh
@@ -8,11 +8,15 @@ set -euo pipefail
 : "${ARROW_VERSION:?ARROW_VERSION (e.g. 24.0.0) must be exported}"
 : "${R_VERSION:?R_VERSION (e.g. 4.4.0) must be exported}"
 
+# P3M manylinux path must be major.minor (4.4), NOT patch (4.4.0).
+# With 4.4.0, P3M returns X-Package-Type=source and packages compile (and fail).
+R_MINOR="${R_VERSION%.*}"
+
 # GHA/build: public P3M (Nexus often unreachable). Runtime users use Nexus via Rprofile.site.
-REPOS="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_VERSION}"
+REPOS="https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/${R_MINOR}"
 
 echo "▶  Arrow portable binary : ${ARROW_VERSION}"
-echo "    ↪ R_VERSION          : ${R_VERSION}"
+echo "    ↪ R_VERSION          : ${R_VERSION} → path ${R_MINOR}"
 echo "    ↪ repos              : ${REPOS}"
 
 Rscript --vanilla -e "install.packages('remotes', repos='${REPOS}', quiet=TRUE)"


### PR DESCRIPTION
## Summary
- Install `arrow` as Posit portable `manylinux_2_28` binary (no APT/system libarrow); pin via `ARROW_VERSION`.
- Point build-time `CRAN` / `r-packages-src.R` at manylinux first, with noble then CRAN fallback.
- Set dual repos in `Rprofile.site` for every RStudio session: Nexus `r-p3m/` then `packagemanager-rstudio-noble`.

## Test plan
- [ ] GHA Docker Image CI builds successfully on Ubuntu noble
- [ ] Image has `arrow` with non-false `arrow_info()\`
- [ ] `getOption('repos')` in RStudio shows P3M manylinux + noble fallback
- [ ] Confirm Nexus `r-p3m` remote is `.../cran/latest/bin/linux/manylinux_2_28-x86_64` (ops)

Made with [Cursor](https://cursor.com)